### PR TITLE
Catch errors from bots.create

### DIFF
--- a/src/maps/Bots.ts
+++ b/src/maps/Bots.ts
@@ -87,18 +87,22 @@ export default class Bots {
      * @param data Bot creation data
      */
     async create(data: Route<'POST', '/bots/create'>["data"]) {
-        let bot = await this.client.req('POST', '/bots/create', data);
-        let user = await this.client.users.fetch(bot._id, {
-            _id: bot._id,
-            username: data.name,
-            bot: {
-                owner: this.client.user!._id
-            }
-        });
-
-        return {
-            bot,
-            user
-        };
+        try {
+            let bot = await this.client.req('POST', '/bots/create', data);
+            let user = await this.client.users.fetch(bot._id, {
+                _id: bot._id,
+                username: data.name,
+                bot: {
+                    owner: this.client.user!._id
+                }
+            });
+    
+            return {
+                bot,
+                user
+            };
+        } catch(err) {
+            throw err;
+        }
     }
 }


### PR DESCRIPTION
This wraps the requests made in the bots.create method in a try catch block, and throws any errors returned. This means that a `.catch(err => ...)` can be used on the [client](https://github.com/revoltchat/revite/) to then show any errors from bot creation, such as name already being taken.