### PR TITLE
fix: added missing `channel` property on message events

### DIFF
--- a/src/websocket/notifications.ts
+++ b/src/websocket/notifications.ts
@@ -47,8 +47,13 @@ export type ClientboundNotification =
     | { type: "Authenticated" }
     | ReadyPacket
     | ({ type: "Message" } & Message)
-    | { type: "MessageUpdate"; id: string; data: Partial<Message> }
-    | { type: "MessageDelete"; id: string }
+    | {
+          type: "MessageUpdate";
+          id: string;
+          data: Partial<Message>;
+          channel: string;
+      }
+    | { type: "MessageDelete"; id: string; channel: string }
     | ({ type: "ChannelCreate" } & Channel)
     | {
           type: "ChannelUpdate";


### PR DESCRIPTION
Not sure why those were removed, but it broke my code and adding them back doesn't seem to cause issues.