### PR TITLE
fix: auto-reconnect if websocket stops sending messages

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -32,6 +32,20 @@ export interface ClientOptions {
     heartbeat: number;
     autoReconnect: boolean;
 
+    /**
+     * Automatically reconnect the client if no
+     * `pong` is received after X seconds of sending a `ping`.
+     * This is a temporary fix for an issue where the client
+     * would randomly stop receiving websocket messages.
+     */
+    pongTimeout?: number;
+
+    /**
+     * If `pongTimeout` is set, this decides what to do when
+     * the timeout is triggered. Default is `RECONNECT`.
+     */
+    onPongTimeout?: "EXIT" | "RECONNECT";
+
     ackRateLimiter: boolean;
 }
 


### PR DESCRIPTION
This attempts to fix an issue where the client randomly stops receiving websocket messages for no apparent reason.

When `pongTimeout` is set in the client config, the client awaits a `Pong` event every time a `Ping` is sent. If no Pong is received within the specified timeout window, the websocket client attempts to reconnect (Or optionally immediately exits).