### PR TITLE
Fix "./Client" cannot be found

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-export * from "./Client";
-export * from "./config";
+export * from "./Client.js";
+export * from "./config.js";
 export {
     UserPermission,
     ChannelPermission,


### PR DESCRIPTION
Fixed a small bug where the file "/dist/Client" cannot be found when importing.
![image](https://user-images.githubusercontent.com/76881234/154814610-1772886c-7316-4b10-86c7-a3dc6cafe7f2.png)