### PR TITLE
fix: bulk message delete uses wrong http method

### DIFF
--- a/src/maps/Channels.ts
+++ b/src/maps/Channels.ts
@@ -566,11 +566,9 @@ export class Channel {
     }
 
     async deleteMessages(ids: string[]) {
-        await this.client.api.post(
-            // @ts-expect-error .delete does not support params
+        await this.client.api.delete(
             `/channels/${this._id as ""}/messages/bulk`,
-            { ids },
-            { method: "DELETE" },
+            { data: { ids } },
         );
     }
 


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
