### PR TITLE
fix: Pass correct payload to bulk delete API call

### DIFF
--- a/src/maps/Channels.ts
+++ b/src/maps/Channels.ts
@@ -580,7 +580,7 @@ export class Channel {
     async deleteMessages(ids: string[]) {
         await this.client.api.delete(
             `/channels/${this._id as ""}/messages/bulk`,
-            { data: { ids } },
+            { ids },
         );
     }
 


### PR DESCRIPTION
DELETE /channels/:id/messages/bulk needs payload to be `{ "ids": [] }`, revolt.js sends `{ "data": { "ids": [] } }`

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
