### PR TITLE
fix: channelId on messageUpdate & honour partial objects

### DIFF
--- a/src/collections/ChannelCollection.ts
+++ b/src/collections/ChannelCollection.ts
@@ -27,7 +27,7 @@ export class ChannelCollection extends ClassCollection<
    */
   async fetch(id: string): Promise<Channel> {
     const channel = this.get(id);
-    if (channel) return channel;
+    if (channel && !this.isPartial(id)) return channel;
     const data = await this.client.api.get(`/channels/${id as ""}`);
     return this.getOrCreate(data._id, data);
   }
@@ -39,7 +39,7 @@ export class ChannelCollection extends ClassCollection<
    * @param isNew Whether this object is new
    */
   getOrCreate(id: string, data: API.Channel, isNew = false) {
-    if (this.has(id)) {
+    if (this.has(id) && !this.isPartial(id)) {
       return this.get(id)!;
     } else {
       const instance = new Channel(this, id);

--- a/src/collections/EmojiCollection.ts
+++ b/src/collections/EmojiCollection.ts
@@ -14,7 +14,7 @@ export class EmojiCollection extends ClassCollection<Emoji, HydratedEmoji> {
    */
   async fetch(id: string): Promise<Emoji> {
     const emoji = this.get(id);
-    if (emoji) return emoji;
+    if (emoji && !this.isPartial(id)) return emoji;
     const data = await this.client.api.get(`/custom/emoji/${id as ""}`);
     return this.getOrCreate(data._id, data);
   }
@@ -26,7 +26,7 @@ export class EmojiCollection extends ClassCollection<Emoji, HydratedEmoji> {
    * @param isNew Whether this object is new
    */
   getOrCreate(id: string, data: API.Emoji, isNew = false) {
-    if (this.has(id)) {
+    if (this.has(id) && !this.isPartial(id)) {
       return this.get(id)!;
     } else {
       const instance = new Emoji(this, id);

--- a/src/collections/MessageCollection.ts
+++ b/src/collections/MessageCollection.ts
@@ -18,7 +18,7 @@ export class MessageCollection extends ClassCollection<
    */
   async fetch(channelId: string, messageId: string): Promise<Message> {
     const message = this.get(messageId);
-    if (message) return message;
+    if (message && !this.isPartial(messageId)) return message;
 
     const data = await this.client.api.get(
       `/channels/${channelId as ""}/messages/${messageId as ""}`
@@ -34,7 +34,7 @@ export class MessageCollection extends ClassCollection<
    * @param isNew Whether this object is new
    */
   getOrCreate(id: string, data: API.Message, isNew = false) {
-    if (this.has(id)) {
+    if (this.has(id) && !this.isPartial(id)) {
       return this.get(id)!;
     } else {
       const instance = new Message(this, id);

--- a/src/collections/ServerCollection.ts
+++ b/src/collections/ServerCollection.ts
@@ -20,7 +20,7 @@ export class ServerCollection extends ClassCollection<Server, HydratedServer> {
    */
   async fetch(id: string): Promise<Server> {
     const server = this.get(id);
-    if (server) return server;
+    if (server && !this.isPartial(id)) return server;
     const data = await this.client.api.get(`/servers/${id as ""}`, {
       include_channels: true,
     });
@@ -44,7 +44,7 @@ export class ServerCollection extends ClassCollection<Server, HydratedServer> {
    * @param isNew Whether this object is new
    */
   getOrCreate(id: string, data: API.Server, isNew = false) {
-    if (this.has(id)) {
+    if (this.has(id) && !this.isPartial(id)) {
       return this.get(id)!;
     } else {
       const instance = new Server(this, id);

--- a/src/collections/ServerMemberCollection.ts
+++ b/src/collections/ServerMemberCollection.ts
@@ -29,6 +29,15 @@ export class ServerMemberCollection extends ClassCollection<
   }
 
   /**
+   * check partial status by composite key
+   * @param id Id
+   * @returns Member
+   */
+  isPartialByKey(id: API.MemberCompositeKey) {
+    return super.isPartial(id.server + id.user);
+  }
+
+  /**
    * Fetch server member by Id
    * @param serverId Server Id
    * @param userId User Id
@@ -36,7 +45,7 @@ export class ServerMemberCollection extends ClassCollection<
    */
   async fetch(serverId: string, userId: string): Promise<ServerMember> {
     const member = this.get(serverId + userId);
-    if (member) return member;
+    if (member && !this.isPartial(serverId + userId)) return member;
 
     const data = (await this.client.api.get(
       `/servers/${serverId as ""}/members/${userId as ""}`,
@@ -55,7 +64,7 @@ export class ServerMemberCollection extends ClassCollection<
    * @param data Data
    */
   getOrCreate(id: API.MemberCompositeKey, data: API.Member) {
-    if (this.hasByKey(id)) {
+    if (this.hasByKey(id) && !this.isPartialByKey(id)) {
       return this.getByKey(id)!;
     } else {
       const instance = new ServerMember(this, id);

--- a/src/collections/UserCollection.ts
+++ b/src/collections/UserCollection.ts
@@ -28,7 +28,7 @@ export class UserCollection extends ClassCollection<User, HydratedUser> {
    */
   async fetch(id: string): Promise<User> {
     const user = this.get(id);
-    if (user) return user;
+    if (user && !this.isPartial(id)) return user;
     const data = await this.client.api.get(`/users/${id as ""}`);
     return this.getOrCreate(data._id, data);
   }
@@ -40,7 +40,7 @@ export class UserCollection extends ClassCollection<User, HydratedUser> {
    * @param isNew Whether this object is new
    */
   getOrCreate(id: string, data: API.User) {
-    if (this.has(id)) {
+    if (this.has(id) && !this.isPartial(id)) {
       return this.get(id)!;
     } else {
       const instance = new User(this, id);

--- a/src/events/v1.ts
+++ b/src/events/v1.ts
@@ -279,10 +279,16 @@ export async function handleEvent(
       if (message) {
         const previousMessage = {
           ...client.messages.getUnderlyingObject(event.id),
+          channelId: event.channel,
         };
 
         client.messages.updateUnderlyingObject(event.id, {
-          ...hydrate("message", event.data, client, false),
+          ...hydrate(
+            "message",
+            { ...event.data, channel: event.channel },
+            client,
+            false
+          ),
           editedAt: new Date(),
         });
 
@@ -295,12 +301,18 @@ export async function handleEvent(
       if (message) {
         const previousMessage = {
           ...client.messages.getUnderlyingObject(event.id),
+          channelId: event.channel,
         };
 
         client.messages.updateUnderlyingObject(
           event.id,
           "embeds",
           (embeds) => [...(embeds ?? []), event.append.embeds ?? []] as Embed[]
+        );
+        client.messages.updateUnderlyingObject(
+          event.id,
+          "channelId",
+          event.channel
         );
 
         client.emit("messageUpdate", message, previousMessage);

--- a/src/hydration/index.ts
+++ b/src/hydration/index.ts
@@ -63,6 +63,11 @@ function hydrateInternal<Input extends object, Output>(
       targetKey = hydration.keyMapping[key] ?? key;
       value = hydration.functions[targetKey as keyof Output](input, context);
     } catch (err) {
+      if (key === "partial")
+        return {
+          ...acc,
+          partial: input,
+        };
       if (key === "type") return acc;
       console.debug(`Skipping key ${String(key)} during hydration!`);
       return acc;

--- a/src/storage/ObjectStorage.ts
+++ b/src/storage/ObjectStorage.ts
@@ -37,6 +37,7 @@ export class ObjectStorage<T> {
    */
   hydrate(id: string, type: keyof Hydrators, context: unknown, data?: unknown) {
     if (data) {
+      data = { partial: false, ...data };
       this.set(id, hydrate(type, data as never, context, true) as T);
     }
   }


### PR DESCRIPTION
* https://github.com/revoltchat/revolt.js/commit/fe325e3628fb056591ad89fc9da4dbf08109a067 adds channel ID (which is supplied by the event) onto partial messages, for those who enabled `partials` in [ClientOptions](https://revolt.js.org/types/ClientOptions.html).
* https://github.com/revoltchat/revolt.js/commit/3ffa0e79e7f0fed6caeb4711c0542be9cdd7d9a8 makes partial properties actually persist in storage (otherwise `isPartial` is useless).
* https://github.com/revoltchat/revolt.js/commit/16b1e60cb2a402d6c9d015fdffdf796b36d6d6be allows partial objects to be converted to full objects whenever the respective fetch methods are called.

## Please make sure to check the following tasks before opening and submitting a PR

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended
