### PR TITLE
Add permission definitions for mentioning everyone, online, and roles

### DIFF
--- a/src/permissions/definitions.ts
+++ b/src/permissions/definitions.ts
@@ -82,8 +82,14 @@ export const Permission = {
   /// Move members between voice channels
   MoveMembers: 2 ** 35,
 
+  // * Mention permissions
+  /// Mention @everyone or @online
+  MentionEveryone: 2 ** 37,
+  /// Mention a role
+  MentionRoles: 2 ** 38,
+
   // * Misc. permissions
-  // % Bits 36 to 52: free area
+  // % Bits 39 to 52: free area
   // % Bits 53 to 64: do not use
 
   // * Grant all permissions


### PR DESCRIPTION
Adds:
- `MentionEveryone = 1 << 37` (@ everyone / @ online )
- `MentionRoles = 1 << 38`

For and dependent on https://github.com/revoltchat/backend/pull/394.

Will likely need backport to v6 so it can be used in Revite. Will advise.

- [X] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [X] I have tested my changes locally and they are working as intended
