### PR TITLE
fix: increase typing timeout to 4s

### DIFF
--- a/src/events/v1.ts
+++ b/src/events/v1.ts
@@ -524,7 +524,7 @@ export async function handleEvent(
                 { ...event, type: "ChannelStopTyping" },
                 setReady,
               ),
-            1000,
+            4000,
           ) as never;
 
           client.emit(


### PR DESCRIPTION
The frontend only sends typing updates every 2.5-3s, so the 1s timeout caused the typing indicator to flicker.

Note that the typing indicators still have some flickering, but it should only be when the user's client sent a StopTyping event, so the source of the flicker is in the sender's typing detection heuristics.

(Given the timeout, I'm not sure if StopTyping events are necessary before a message is actually sent -- would it be simpler to have CurrentlyTyping events with a timeout, and cancel the indicator on the next received message from that user?)

## Please make sure to check the following tasks before opening and submitting a PR

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended
