### PR TITLE
fix: Specify argument in Client "error" event to be Error instead of any.

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -42,8 +42,7 @@ export type Session = { _id: string; token: string; user_id: string } | string;
  * Events provided by the client
  */
 export type Events = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  error: [error: any];
+  error: [error: Error];
 
   connected: [];
   connecting: [];


### PR DESCRIPTION
I don't see a reason for this to be `any`, so I am updating this to be an `Error` instead for the type system.

Only location where the `"error"` event was emitted (I think): https://github.com/stoatchat/javascript-client-sdk/blob/cdf406094b9b81c3ff285b14ed97fb3d138e3061/src/Client.ts#L263

Callback argument type where that `"error"` event comes from: https://github.com/stoatchat/javascript-client-sdk/blob/cdf406094b9b81c3ff285b14ed97fb3d138e3061/src/events/EventClient.ts#L70
