### PR TITLE
fix: correct event name in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ client.on("ready", async () =>
   console.info(`Logged in as ${client.user.username}!`),
 );
 
-client.on("messageCreate", async (message) => {
+client.on("message", async (message) => {
   if (message.content === "hello") {
     message.channel.sendMessage("world");
   }


### PR DESCRIPTION
Hey, thanks for what looks like a nice library! Just starting out, it seems like the event name in the "Example Usage" is wrong - it's `message` and not `messageCreate`?

Reference: https://developers.stoat.chat/developers/events/protocol#message