### PR TITLE
fix: server deletion lockup

### DIFF
--- a/src/classes/Server.ts
+++ b/src/classes/Server.ts
@@ -136,9 +136,10 @@ export class Server {
    * Channels
    */
   get channels(): Channel[] {
-    return [
-      ...this.#collection.getUnderlyingObject(this.id).channelIds.values(),
-    ]
+    const channelIds = this.#collection.getUnderlyingObject(this.id).channelIds;
+    if (!channelIds) return [];
+
+    return [...channelIds.values()]
       .map((id) => this.#collection.client.channels.get(id)!)
       .filter((x) => x);
   }
@@ -338,6 +339,7 @@ export class Server {
    * Permission the currently authenticated user has against this server
    */
   get permission(): bigint {
+    if (!this.$exists) return 0n;
     return calculatePermission(this.#collection.client, this);
   }
 

--- a/src/events/EventClient.ts
+++ b/src/events/EventClient.ts
@@ -94,11 +94,8 @@ export class EventClient<
   #pongTimeoutReference: number | undefined;
   #connectTimeoutReference: number | undefined;
 
-  #lastError:
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    | { type: "socket"; data: any }
-    | { type: "revolt"; data: Error }
-    | undefined;
+  #lastError: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { type: "socket"; data: any } | { type: "revolt"; data: Error } | undefined;
 
   /**
    * Create a new event client.

--- a/src/events/EventClient.ts
+++ b/src/events/EventClient.ts
@@ -94,8 +94,11 @@ export class EventClient<
   #pongTimeoutReference: number | undefined;
   #connectTimeoutReference: number | undefined;
 
-  #lastError: // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    { type: "socket"; data: any } | { type: "revolt"; data: Error } | undefined;
+  #lastError:
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    | { type: "socket"; data: any }
+    | { type: "revolt"; data: Error }
+    | undefined;
 
   /**
    * Create a new event client.


### PR DESCRIPTION
Fixes client lockup "can't access property 'values'" and "can't convert undefined to BigInt" on server deletion or server leave by adding safe returns on object deletion

---
Closes: https://github.com/stoatchat/for-web/issues/574
https://github.com/stoatchat/for-web/issues/641

---
Supersedes: https://github.com/stoatchat/for-web/pull/803