### PR TITLE
fix: markdownToTextFetch will now return results even if fetches fail

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -455,10 +455,14 @@ export class Client extends AsyncEventEmitter<Events> {
       async (key) => {
         const substr = userMatches[key];
         if (substr) {
-          const user = await this.users.fetch(substr);
-
-          if (user) {
-            return [key, `@${user.username}`];
+          try {
+            const user = await this.users.fetch(substr);
+            if (user) {
+              return [key, `@${user.username}`];
+            }
+          } catch {
+            // If the fetch fails, just show the match as a default
+            return [key, key];
           }
         }
 
@@ -471,10 +475,14 @@ export class Client extends AsyncEventEmitter<Events> {
       async (key) => {
         const substr = channelMatches[key];
         if (substr) {
-          const channel = await this.channels.fetch(substr);
-
-          if (channel) {
-            return [key, `#${channel.displayName}`];
+          try {
+            const channel = await this.channels.fetch(substr);
+            if (channel) {
+              return [key, `#${channel.displayName}`];
+            }
+          } catch {
+            // If the fetch fails, just show the match as a default
+            return [key, key];
           }
         }
 
@@ -487,10 +495,14 @@ export class Client extends AsyncEventEmitter<Events> {
       async (key) => {
         const substr = customEmojiMatches[key];
         if (substr) {
-          const emoji = await this.emojis.fetch(substr);
-
-          if (emoji) {
-            return [key, `:${emoji.name}:`];
+          try {
+            const emoji = await this.emojis.fetch(substr);
+            if (emoji) {
+              return [key, `:${emoji.name}:`];
+            }
+          } catch {
+            // If the fetch fails, just show the match as a default
+            return [key, key];
           }
         }
 


### PR DESCRIPTION
Insert brought up a scenario where markdownToTextFetch would fail if a fetch to the backend failed. This PR makes the function default to the ulid string if the fetch fails.