### PR TITLE
docs: Add some notes that Client.connect() should be called after Client.login()

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -326,7 +326,8 @@ export class Client extends AsyncEventEmitter<Events> {
   }
 
   /**
-   * Connect to Revolt
+   * Connect to Revolt.
+   * To be called after `client.login`'s `Promise` resolves.
    */
   connect(): void {
     clearTimeout(this.#reconnectTimeout);
@@ -362,6 +363,7 @@ export class Client extends AsyncEventEmitter<Events> {
 
   /**
    * Log in with auth data, creating a new session in the process.
+   * Does not automatically connect. A call to `Client.connect()` is required after this `Promise` resolves
    * @param details Login data object
    * @returns An on-boarding function if on-boarding is required, undefined otherwise
    */
@@ -385,7 +387,8 @@ export class Client extends AsyncEventEmitter<Events> {
   }
 
   /**
-   * Log in as a bot
+   * Log in as a bot.
+   * Automatically connects
    * @param token Bot token
    */
   async loginBot(token: string): Promise<void> {

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -327,7 +327,7 @@ export class Client extends AsyncEventEmitter<Events> {
 
   /**
    * Connect to Revolt.
-   * To be called after `client.login`'s `Promise` resolves.
+   * To be called after `client.login`'s `Promise` resolves
    */
   connect(): void {
     clearTimeout(this.#reconnectTimeout);


### PR DESCRIPTION
Fixes the documentation problem this guy encountered: https://github.com/stoatchat/javascript-client-sdk/issues/139

These lines can be there until the `await this.connect();` line in `Client.login()` is not commented out.

Irrelevant but why is it commented out anyway? It looks fine to me and `Client.loginBot()` is already doing that so far.