### PR TITLE
fix: Client.uploadFile(): Restrict tag choices to those specified in the API docs

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -41,6 +41,8 @@ import {
   RE_SPOILER,
 } from "./lib/regex.js";
 
+export type Tag = "attachments" | "avatars" | "backgrounds" | "icons" | "banners" | "emojis";
+
 export type Session = { _id: string; token: string; user_id: string } | string;
 
 /**
@@ -555,9 +557,10 @@ export class Client extends AsyncEventEmitter<Events> {
    * @param tag Tag
    * @param file File
    * @param uploadUrl Media server upload route
+   * @returns File ID
    */
   async uploadFile(
-    tag: string,
+    tag: Tag,
     file: File,
     uploadUrl?: string,
   ): Promise<string> {


### PR DESCRIPTION
Currently, you can essentially give it random garbage, even if [the API docs page for it](https://cdn.stoatusercontent.com/scalar#tag/api/GET/) clearly states that only 6 specific paths work.

There is probably a better solution than "hard-code a large string-literal union", but so far I haven't found it yet