### PR TITLE
fix: Animate avatars/icons that's using the `.webp` file format

### DIFF
--- a/src/classes/File.ts
+++ b/src/classes/File.ts
@@ -117,7 +117,7 @@ export class File {
     if (!autumn?.enabled) return;
 
     let query = "";
-    if (forceAnimation && this.contentType === "image/gif") {
+    if (forceAnimation && (this.contentType === "image/gif" || this.contentType === "image/webp")) {
       query = "/original";
     }
 


### PR DESCRIPTION
WebP can be animated, and so—it should have the same effect as normal GIFs—having the loop animation than it just being static.