### PR TITLE
fix: fetch server configuration on client initialization for invite_only servers

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -200,6 +200,8 @@ export class Client extends AsyncEventEmitter<Events> {
   #setConnectionFailureCount: Setter<number>;
   #reconnectTimeout: number | undefined;
 
+  #configurationFetched: boolean;
+
   /**
    * Create Stoat.js Client
    */
@@ -242,14 +244,13 @@ export class Client extends AsyncEventEmitter<Events> {
     };
 
     this.configuration = configuration;
+    this.#configurationFetched = false;
 
     this.api = new API({
       baseURL: this.options.baseURL,
     });
 
-    const [configured, setConfigured] = createSignal(
-      configuration !== undefined,
-    );
+    const [configured, setConfigured] = createSignal(false);
     this.configured = configured;
     this.#setConfigured = setConfigured;
 
@@ -339,13 +340,13 @@ export class Client extends AsyncEventEmitter<Events> {
   }
 
   /**
-   * Fetches the configuration of the server if it has not been already fetched.
+   * Fetches the configuration from the server if not already fetched.
    */
   async #fetchConfiguration(): Promise<void> {
-    if (!this.configuration) {
-      this.configuration = await this.api.get("/");
-      this.#setConfigured(true);
-    }
+    if (this.#configurationFetched) return;
+    this.configuration = await this.api.get("/");
+    this.#configurationFetched = true;
+    this.#setConfigured(true);
   }
 
   /**


### PR DESCRIPTION
When invite_only: true is set on a Stoat server, the registration form in the web frontend never displays the "Invite Code" input field, making it impossible to register on invite-only instances via the UI.

note: I'm not a typescript dev and this was written by AI.

Thanks :)

## Root Cause

The Client constructor in `javascript-client-sdk/src/Client.ts` initializes configured to true whenever a default configuration is passed in (which `Controller.ts` always does). The `#fetchConfiguration()` method then skips fetching the real server config because `this.configuration` is already truthy.

As a result, `features.invite_only` was always false (the hardcoded default), so `FlowCreate.tsx`'s `<Show when={isInviteOnly()}>` never rendered the invite field.

## Changes

`javascript-client-sdk/src/Client.ts`
- Add `#configurationFetched` flag to track whether the server config has been fetched
- Initialize configured signal to false instead of inferring from whether a default config was passed
- `#fetchConfiguration()` now always fetches the real server config on first call, then caches

The frontend code in `FlowCreate.tsx` and `Form.tsx` was already correct — it just never received the real server config to read invite_only from.

## Testing

- Start a Stoat instance with invite_only: true in Revolt.toml
- Visit the web frontend registration page — the "Invite Code" field should now appear
- Submit with a valid invite code — registration should succeed
- Non-invite-only instances should continue to work as before (no invite field shown)