### PR TITLE
feat: Add the ability to get a user's limits, including current

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -4,7 +4,7 @@ import { batch, createSignal } from "solid-js";
 import { ReactiveMap } from "@solid-primitives/map";
 import { AsyncEventEmitter } from "@vladfrangu/async_event_emitter";
 import { API } from "stoat-api";
-import type { DataLogin, RevoltConfig, Role } from "stoat-api";
+import type { DataLogin, RevoltConfig, Role, UserLimits } from "stoat-api";
 
 import type { Channel } from "./classes/Channel.js";
 import type { Emoji } from "./classes/Emoji.js";
@@ -609,5 +609,13 @@ export class Client extends AsyncEventEmitter<Events> {
     }, data.retry_after * 1000);
 
     this.#slowmodeTimers.set(channelId, timer);
+  }
+
+  getLimits(): UserLimits | undefined {
+    if (!this.configured() || !this.user) {
+      return;
+    }
+
+    return this.user.getLimits();
   }
 }

--- a/src/classes/User.ts
+++ b/src/classes/User.ts
@@ -1,4 +1,9 @@
-import type { User as APIUser, DataEditUser, Presence } from "stoat-api";
+import type {
+  User as APIUser,
+  DataEditUser,
+  Presence,
+  UserLimits,
+} from "stoat-api";
 import { decodeTime } from "ulid";
 
 import type { UserCollection } from "../collections/UserCollection.js";
@@ -46,6 +51,13 @@ export class User {
    */
   get createdAt(): Date {
     return new Date(decodeTime(this.id));
+  }
+
+  /**
+   * How old this user is in milliseconds
+   */
+  get age() {
+    return new Date().getTime() - this.createdAt.getTime();
   }
 
   /**
@@ -333,5 +345,20 @@ export class User {
     return await this.#collection.client.api.get(
       `/users/${this.id as ""}/mutual`,
     );
+  }
+
+  getLimits(): UserLimits | undefined {
+    if (!this.#collection.client.configured()) {
+      return;
+    }
+    if (
+      this.age <
+      (this.#collection.client.configuration?.features.limits.global
+        .new_user_hours ?? 72) *
+        3600_0000
+    ) {
+      return this.#collection.client.configuration?.features.limits.new_user;
+    }
+    return this.#collection.client.configuration?.features.limits.default;
   }
 }


### PR DESCRIPTION
This PR adds the ability to fetch a user's limits. It adds `getLimits` to the user object, which returns either the new user limits or the default limits based on the age of the user. This can later be expanded to include `premium` user types easily. The `getLimits` function will return undefined if the client is unconfigured.  This PR also adds a `getLimits` function to the client that shortcuts calling `getLimits` on the currently logged in user.

Generative AI was not used in the writing of this PR.