### PR TITLE
feat: Add a logout function for disposal of the client

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -398,7 +398,7 @@ export class Client extends AsyncEventEmitter<Events> {
   /**
    * Log out of current session
    *
-   * This funciton prepares the client for disposal by removing all event listeners and killing the events socket.
+   * This function prepares the client for disposal by removing all event listeners and killing the events socket.
    */
   async logout(): Promise<void> {
     await this.api.post("/auth/session/logout");

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -396,6 +396,18 @@ export class Client extends AsyncEventEmitter<Events> {
   }
 
   /**
+   * Log out of current session
+   *
+   * This funciton prepares the client for disposal by removing all event listeners and killing the events socket.
+   */
+  async logout(): Promise<void> {
+    await this.api.post("/auth/session/logout");
+    this.events.removeAllListeners();
+    this.removeAllListeners();
+    this.events.disconnect();
+  }
+
+  /**
    * Prepare a markdown-based message to be displayed to the user as plain text.
    * @param source Source markdown text
    * @returns Modified plain text


### PR DESCRIPTION
Adds a logout function on the client that calls `/auth/session/logout` which deletes sessions. It also disposes the client. This moves the `dispose` functionality from for-web to the sdk.

Gen AI was not used in the writing of this PR.