### PR TITLE
chore: Add tsconfigRootDir to eslint to fix linting in for-web

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,11 @@ import { defineConfig } from "eslint/config";
 import tseslint from "typescript-eslint";
 
 export default defineConfig([
+  {
+    languageOptions: {
+      parserOptions: { tsconfigRootDir: import.meta.dirname },
+    },
+  },
   eslint.configs.recommended,
   tseslint.configs.recommended,
   solid,


### PR DESCRIPTION
Add tsconfigRootDir to eslint config to silence errors in for-web regarding lint