### PR TITLE
fix: Race condition on init & add method for overriding config options

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -205,8 +205,9 @@ export class Client extends AsyncEventEmitter<Events> {
   #reconnectTimeout: number | undefined;
   #slowmodeTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
-  /** Create Stoat.js Client
-  @param configuration Deprecated - Please use `Client.initConfig` if you need to override config.
+  /**
+   * Create Stoat.js Client
+   * @param configuration Deprecated - Please use `Client.initConfig` if you need to override config.
    */
   constructor(options?: Partial<ClientOptions>, configuration?: RevoltConfig) {
     super();
@@ -342,9 +343,17 @@ export class Client extends AsyncEventEmitter<Events> {
     );
   }
 
-  /** Fetches the server config. This is called automatically by login() or loginBot(),
-   * but you can call it manually first if you need to override any config options.
-   * @param preConfig Called after fetch, but before configured() flag is set */
+  /**
+   * Fetches the server config. This is called automatically by `login()` or `loginBot()`,
+   * but you can call it first manually if you need to override any config options.
+   *
+   * Override example:
+   * ```ts
+   * await client.initConfig(() => {
+   *   cli.configuration!.ws = "wss://example.com";
+   * });
+   * ```
+   */
   async initConfig(preConfig?: () => void): Promise<void> {
     if (!this.#configLock && !this.configuration) {
       //Create promise lock to avoid race condition

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -189,7 +189,8 @@ export class Client extends AsyncEventEmitter<Events> {
   readonly options: ClientOptions;
   readonly events: EventClient<1>;
 
-  configuration: RevoltConfig | undefined;
+  readonly configuration: RevoltConfig | undefined;
+  #configLock?: Promise<void>;
   #session: Session | undefined;
   user: User | undefined;
 
@@ -203,8 +204,9 @@ export class Client extends AsyncEventEmitter<Events> {
   #setConnectionFailureCount: Setter<number>;
   #reconnectTimeout: number | undefined;
   #slowmodeTimers = new Map<string, ReturnType<typeof setTimeout>>();
-  /**
-   * Create Stoat.js Client
+
+  /** Create Stoat.js Client
+  @param configuration Deprecated - Please use `Client.initConfig` if you need to override config.
    */
   constructor(options?: Partial<ClientOptions>, configuration?: RevoltConfig) {
     super();
@@ -255,8 +257,6 @@ export class Client extends AsyncEventEmitter<Events> {
     );
     this.configured = configured;
     this.#setConfigured = setConfigured;
-
-    this.#fetchConfiguration();
 
     const [ready, setReady] = createSignal(false);
     this.ready = ready;
@@ -342,14 +342,20 @@ export class Client extends AsyncEventEmitter<Events> {
     );
   }
 
-  /**
-   * Fetches the configuration of the server if it has not been already fetched.
-   */
-  async #fetchConfiguration(): Promise<void> {
-    if (!this.configuration) {
-      this.configuration = await this.api.get("/");
-      this.#setConfigured(true);
+  /** Fetches the server config. This is called automatically by login() or loginBot(),
+   * but you can call it manually first if you need to override any config options.
+   * @param preConfig Called after fetch, but before configured() flag is set */
+  async initConfig(preConfig?: () => void): Promise<void> {
+    if (!this.#configLock && !this.configuration) {
+      //Create promise lock to avoid race condition
+      this.#configLock = (async () => {
+        //@ts-expect-error readonly override
+        this.configuration = await this.api.get("/");
+        preConfig?.();
+        this.#setConfigured(true);
+      })();
     }
+    return this.#configLock;
   }
 
   /**
@@ -370,7 +376,7 @@ export class Client extends AsyncEventEmitter<Events> {
    * @returns An on-boarding function if on-boarding is required, undefined otherwise
    */
   async login(details: DataLogin): Promise<void> {
-    await this.#fetchConfiguration();
+    await this.initConfig();
     const data = await this.api.post("/auth/session/login", details);
     if (data.result === "Success") {
       this.#session = data;
@@ -393,7 +399,7 @@ export class Client extends AsyncEventEmitter<Events> {
    * @param token Bot token
    */
   async loginBot(token: string): Promise<void> {
-    await this.#fetchConfiguration();
+    await this.initConfig();
     this.#session = token;
     this.#updateHeaders();
     this.connect();
@@ -614,10 +620,6 @@ export class Client extends AsyncEventEmitter<Events> {
    * Backend enforced limits for the logged in user
    */
   get limits(): UserLimits | undefined {
-    if (!this.configured() || !this.user) {
-      return;
-    }
-
-    return this.user.limits;
+    if (this.configured() && this.user) return this.user.limits;
   }
 }

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -353,6 +353,7 @@ export class Client extends AsyncEventEmitter<Events> {
         this.configuration = await this.api.get("/");
         preConfig?.();
         this.#setConfigured(true);
+        this.#configLock = undefined;
       })();
     }
     return this.#configLock;

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -349,18 +349,18 @@ export class Client extends AsyncEventEmitter<Events> {
    *
    * Override example:
    * ```ts
-   * await client.initConfig(() => {
-   *   cli.configuration!.ws = "wss://example.com";
+   * await client.initConfig((config) => {
+   *   config.ws = "wss://example.com";
    * });
    * ```
    */
-  async initConfig(preConfig?: () => void): Promise<void> {
+  async initConfig(preConfig?: (config: RevoltConfig) => void): Promise<void> {
     if (!this.#configLock && !this.configuration) {
       //Create promise lock to avoid race condition
       this.#configLock = (async () => {
         //@ts-expect-error readonly override
         this.configuration = await this.api.get("/");
-        preConfig?.();
+        preConfig?.(this.configuration);
         this.#setConfigured(true);
         this.#configLock = undefined;
       })();


### PR DESCRIPTION
Should fix race condition upon config fetch without breaking any compatibility, while also providing a much more reliable means of overriding individual config options *before* the `configured()` flag is set, solving two related race conditions in one go.
