### PR TITLE
fix: nix shell not working

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,12 +1,9 @@
 {
   pkgs ? import <nixpkgs> { },
-}:
-
-with pkgs;
-pkgs.mkShell {
+}: pkgs.mkShell {
   name = "stoatEnv";
 
-  buildInputs = [
+  buildInputs = with pkgs; [
     # Tools
     git
     gh
@@ -14,6 +11,6 @@ pkgs.mkShell {
 
     # Node
     nodejs
-    nodejs.pkgs.pnpm
+    pnpm_10
   ];
 }


### PR DESCRIPTION
Edited the `default.nix` file to be a little bit cleaner and use `pkgs.pnpm_10` instead of the now removed `nodejs.pkgs.pnpm` (`pkgs.nodePackages.pnpm`)