### PR TITLE
feat: audit log

### DIFF
--- a/src/classes/Server.ts
+++ b/src/classes/Server.ts
@@ -3,8 +3,10 @@ import { batch } from "solid-js";
 import type { ReactiveMap } from "@solid-primitives/map";
 import type { ReactiveSet } from "@solid-primitives/set";
 import type {
+  APIRoutes,
   Server as APIServer,
   AllMemberResponse,
+  AuditLogEntry,
   BannedUser,
   Category,
   DataBanCreate,
@@ -371,6 +373,36 @@ export class Server {
       server: this.id,
       user: userId,
     });
+  }
+  /**
+   * @param params
+   * @returns This server's tracked actions, members and users
+   */
+  async getAuditLogs(
+    params?: (APIRoutes & {
+      method: "get";
+      path: "/servers/{target}/audit_logs";
+      parts: 3;
+    })["params"],
+  ): Promise<{
+    audit_logs: AuditLogEntry[];
+    users: User[];
+    members: ServerMember[];
+  }> {
+    const logs = await this.#collection.client.api.get(
+      `/servers/${this.id as ""}/audit_logs`,
+      { ...params },
+    );
+
+    return batch(() => ({
+      audit_logs: logs.audit_logs,
+      users: logs.users.map((user) =>
+        this.#collection.client.users.getOrCreate(user._id, user),
+      ),
+      members: logs.members.map((member) =>
+        this.#collection.client.serverMembers.getOrCreate(member._id, member),
+      ),
+    }));
   }
 
   /**

--- a/src/permissions/definitions.ts
+++ b/src/permissions/definitions.ts
@@ -92,8 +92,11 @@ export const Permission = {
   /// Mention a role
   MentionRoles: 2n ** 38n,
 
+  // Access server audit logs
+  ViewAuditLogs: 2n ** 40n,
+
   // * Misc. permissions
-  // % Bits 39 to 52: free area
+  // % Bits 41 to 52: free area
   // % Bits 53 to 64: do not use
 
   // * Grant all permissions


### PR DESCRIPTION
This PR adds `getAuditLogs()`, a prerequisite for the upcoming Audit Log UI in Stoat for Web.