### PR TITLE
fix: allow passing MFA tickets when changing an account's email address

### DIFF
--- a/src/collections/AccountCollection.ts
+++ b/src/collections/AccountCollection.ts
@@ -1,7 +1,7 @@
 import type { DataCreateAccount, WebPushSubscription } from "stoat-api";
 
 import type { Client } from "../Client.js";
-import { MFA, MFATicket } from "../classes";
+import { MFA, MFATicket } from "../classes/MFA.js";
 
 /**
  * Utility functions for working with accounts
@@ -125,9 +125,7 @@ export class AccountCollection {
         email: newEmail,
         current_password: currentPassword,
       },
-      {
-        headers: ticket ? { "X-MFA-Ticket": ticket.token } : undefined,
-      },
+      ticket ? { headers: { "X-MFA-Ticket": ticket.token } } : undefined
     );
   }
 

--- a/src/collections/AccountCollection.ts
+++ b/src/collections/AccountCollection.ts
@@ -1,7 +1,7 @@
 import type { DataCreateAccount, WebPushSubscription } from "stoat-api";
 
 import type { Client } from "../Client.js";
-import { MFA } from "../classes/MFA.js";
+import { MFA, MFATicket } from "../classes";
 
 /**
  * Utility functions for working with accounts
@@ -111,12 +111,24 @@ export class AccountCollection {
    * Change account email
    * @param newEmail New email
    * @param currentPassword Current password
+   * @param ticket MFA ticket, mandatory if account has MFA enabled
    */
-  changeEmail(newEmail: string, currentPassword: string): Promise<void> {
-    return this.client.api.patch("/auth/account/change/email", {
-      email: newEmail,
-      current_password: currentPassword,
-    });
+  changeEmail(
+    newEmail: string,
+    currentPassword: string,
+    ticket?: MFATicket,
+  ): Promise<void> {
+    ticket?._consume();
+    return this.client.api.patch(
+      "/auth/account/change/email",
+      {
+        email: newEmail,
+        current_password: currentPassword,
+      },
+      {
+        headers: ticket ? { "X-MFA-Ticket": ticket.token } : undefined,
+      },
+    );
   }
 
   /**


### PR DESCRIPTION
Adds an optional `MFATicket` parameter to `AccountCollection.changeEmail()`.

Currently, accounts with MFA enabled fail when trying to change their email address because the backend [endpoint mandates](https://github.com/stoatchat/stoatchat/blob/457c7709c75060cd8519cc45df3badcfc1b629ea/crates/delta/src/routes/account/change_email.rs#L26-L28) a verified ticket, but the SDK didn't expose any way to pass one (unlike [`Session.delete()`](https://github.com/stoatchat/javascript-client-sdk/blob/addfc29ce69098ca4a3c649c7eda07629f7050a8/src/classes/Session.ts#L75-L87)).

Fixes #178 