### PR TITLE
fix: don't drop role_mentions when hydrating messages

### DIFF
--- a/src/hydration/message.ts
+++ b/src/hydration/message.ts
@@ -40,6 +40,7 @@ export const messageHydration: Hydrate<Merge<Message>, HydratedMessage> = {
     system: "systemMessage",
     edited: "editedAt",
     mentions: "mentionIds",
+    role_mentions: "roleMentionIds",
     replies: "replyIds",
   },
   functions: {


### PR DESCRIPTION
`keyMapping` in `src/hydration/message.ts` was missing an entry for `role_mentions`, causing the field to be silently dropped on every message.

`hydrateInternal` maps incoming payload keys through `keyMapping[key] ?? key` before calling `functions[targetKey]`. Without an entry in `keyMapping`, the key stayed as the raw API string (`role_mentions`). Since no handler existed under that name, it threw an error that got caught and swallowed by the fallback log ("Skipping key ... during hydration!").

As a result, `roleMentionIds` was never populated and the extractor function right below the mapping was completely bypassed. `Message.roleMentions` therefore always returned `undefined`, and `Message.mentioned` - which checks `roleMentions?.some((role) => role.assigned)` - could never evaluate to true for role mentions.

Adding the missing mapping lets the existing extractor run as expected.

Related to stoatchat/for-web#1461. This won't automatically close that issue, since `for-web` vendors this package as a submodule and will need its reference updated after this lands.

## How was this PR tested?

- [x] Ran `hydrate()` against a message payload containing both `mentions` and `role_mentions`. Previously, this output `roleMentionIds: undefined` alongside the "Skipping key role_mentions" log; with this change, it populates `roleMentionIds: ["01RRR..."]`. Standard user mentions remained unaffected.
- [x] Built the package and loaded it in the web client: verified that messages mentioning a role I hold now trigger the expected highlight, and the skipped-key log is gone.
- [x] Ran `tsc --noEmit` and `prettier --check` (both passed clean).

<details><summary><h2>Screenshots & Screencasts (if appropriate)</h2></summary>

Active Session on Stoat Chat Desktop Client on Same Account
<img width="785" height="190" alt="Screenshot 2026-08-08 at 1 10 17 PM" src="https://github.com/user-attachments/assets/f2b260f9-0571-4f30-9b14-0787be40096a" />

Web Client Session with Fix Applied 
<img width="889" height="211" alt="Screenshot 2026-08-08 at 1 08 57 PM" src="https://github.com/user-attachments/assets/3ee18426-e93a-46dc-937f-e2db652ce7b0" />

</details>

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None - Updated to remove em dashes placed automatically by Grammarly. No AI used in PR or Coding.